### PR TITLE
use embedded_hal_async::i2c::I2c in I2CDisplayInterface if feature 'a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ SSD1306 monochrome OLED display.
 
 ## [Unreleased] - ReleaseDate
 
+ - use embedded_hal_async::i2c::I2c in I2CDisplayInterface if feature 'async' is enabled to enable embassy_embedded_hal::shared_bus::asynch::i2c
+
 ## [0.9.0] - 2024-08-30
 
 - Updated dependencies for `embedded-hal` 1.0.0.

--- a/src/i2c_interface.rs
+++ b/src/i2c_interface.rs
@@ -8,6 +8,7 @@ pub struct I2CDisplayInterface(());
 
 impl I2CDisplayInterface {
     /// Create new builder with a default I2C address of 0x3C
+    #[cfg(not(feature = "async"))]
     #[allow(clippy::new_ret_no_self)]
     // pub fn with_i2c<I>(i2c: I) -> I2CInterface<I> // alternative, but breaking change
     pub fn new<I>(i2c: I) -> I2CInterface<I>
@@ -16,7 +17,17 @@ impl I2CDisplayInterface {
     {
         Self::new_custom_address(i2c, 0x3C)
     }
+    #[cfg(feature = "async")]
+    #[allow(clippy::new_ret_no_self)]
+    /// Create a new async I2C interface with the address 0x3D
+    pub fn new<I>(i2c: I) -> I2CInterface<I>
+    where
+        I: embedded_hal_async::i2c::I2c,
+    {
+        Self::new_custom_address(i2c, 0x3C)
+    }
 
+    #[cfg(not(feature = "async"))]
     /// Create a new I2C interface with the alternate address 0x3D as specified in the datasheet.
     pub fn new_alternate_address<I>(i2c: I) -> I2CInterface<I>
     where
@@ -25,10 +36,28 @@ impl I2CDisplayInterface {
         Self::new_custom_address(i2c, 0x3D)
     }
 
+    #[cfg(feature = "async")]
+    /// Create a new async I2C interface with the alternate address 0x3D as specified in the datasheet.
+    pub fn new_alternate_address<I>(i2c: I) -> I2CInterface<I>
+    where
+        I: embedded_hal_async::i2c::I2c,
+    {
+        Self::new_custom_address(i2c, 0x3D)
+    }
+
+    #[cfg(not(feature = "async"))]
     /// Create a new I2C interface with a custom address.
     pub fn new_custom_address<I>(i2c: I, address: u8) -> I2CInterface<I>
     where
         I: embedded_hal::i2c::I2c,
+    {
+        I2CInterface::new(i2c, address, 0x40)
+    }
+    #[cfg(feature = "async")]
+    /// Create a new  async I2C interface with a custom address.
+    pub fn new_custom_address<I>(i2c: I, address: u8) -> I2CInterface<I>
+    where
+        I: embedded_hal_async::i2c::I2c,
     {
         I2CInterface::new(i2c, address, 0x40)
     }


### PR DESCRIPTION
use embedded_hal_async::i2c::I2c in I2CDisplayInterface if feature 'async' is enabled to enable embassy_embedded_hal::shared_bus::asynch::i2c

With embassy_embedded_hal::shared_bus::asynch::i2c  you can share the same i2c  for multiple  devices. 
I.e.

use embassy_embedded_hal::shared_bus::asynch::i2c::I2cDevice;
use embassy_sync::mutex::Mutex;
use embassy_sync::blocking_mutex::raw::NoopRawMutex;

static I2C_BUS: StaticCell<Mutex<NoopRawMutex, Twim<TWISPI0>>> = StaticCell::new();
let config = twim::Config::default();
let i2c = Twim::new(p.TWISPI0, Irqs, p.P0_03, p.P0_04, config);
let i2c_bus = Mutex::new(i2c);
let i2c_bus = I2C_BUS.init(i2c_bus);
// first device on the bus
let interface = I2CDisplayInterface::new(I2cDevice::new(i2c_bus));
let mut display = Ssd1306Async::new(interface, DisplaySize128x32, DisplayRotation::Rotate0).into_terminal_mode();
//second device on the bus
let mut ms5611 = Ms5611::new(I2cDevice::new(i2c_bus), None).await.unwrap();

