### PR TITLE
Pin maybe-async-cfg to version 0.2.4 due to breaking changes in latest.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ display-interface-i2c = "0.5.0"
 display-interface-spi = "0.5.0"
 embedded-graphics-core = { version = "0.4.0", optional = true }
 embedded-hal-async = { version = "1.0.0",  optional = true }
-maybe-async-cfg = "0.2.4"
+maybe-async-cfg = "=0.2.4"
 
 [dev-dependencies]
 embedded-graphics = "0.8.0"


### PR DESCRIPTION
With the configuration currently in master

> cargo build --all-features --release

Will use the latest `maybe-async-cfg` which is `0.2.5`. This causes compilation errors.

This change pins the version to `=0.2.4` rather than attempting to upgrade to the latest version. I'll leave that as an excersise to someone with more experience with maybe-async-cfg.

--
Details about the errors encountered:

When 0.2.5 is selected we see the following compilation errors and many other similar ones:

```bash
error[E0277]: `Result<(), DisplayError>` is not a future
   --> src/size.rs:184:56
    |
184 |         Command::ComPinConfig(true, false).send(iface).await
    |                                                       -^^^^^
    |                                                       ||
    |                                                       |`Result<(), DisplayError>` is not a future
    |                                                       help: remove the `.await`
    |
    = help: the trait `Future` is not implemented for `Result<(), DisplayError>`, which is required by `Result<(), DisplayError>: IntoFuture`
    = note: Result<(), DisplayError> must be a future or must implement `IntoFuture` to be awaited
    = note: required for `Result<(), DisplayError>` to implement `IntoFuture`

error[E0119]: conflicting implementations of trait `size::DisplaySize` for type `size::DisplaySize128x64`
  --> src/size.rs:77:1
   |
77 | impl DisplaySize for DisplaySize128x64 {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   | |
   | first implementation here
   | conflicting implementation for `size::DisplaySize128x64`
error[E0277]: the trait bound `size::DisplaySize128x32: DisplaySizeAsync` is not satisfied
  --> src/mode/terminal.rs:48:30
   |
48 | impl TerminalDisplaySize for DisplaySize128x32 {
   |                              ^^^^^^^^^^^^^^^^^ the trait `DisplaySizeAsync` is not implemented for `size::DisplaySize128x32`
   |
help: this trait has no implementations, consider adding one
  --> src/size.rs:33:1
   |
33 | pub trait DisplaySize {
   | ^^^^^^^^^^^^^^^^^^^^^
note: required by a bound in `TerminalDisplaySizeAsync`
  --> src/mode/terminal.rs:23:32
   |
23 | pub trait TerminalDisplaySize: DisplaySize {
   |                                ^^^^^^^^^^^ required by this bound in `TerminalDisplaySizeAsync`
```