### PR TITLE
Add DisplaySize64x32 to prelude

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,8 +9,8 @@ pub use super::{
     mode::DisplayConfig,
     rotation::DisplayRotation,
     size::{
-        DisplaySize, DisplaySize128x32, DisplaySize128x64, DisplaySize64x48, DisplaySize72x40,
-        DisplaySize96x16,
+        DisplaySize, DisplaySize128x32, DisplaySize128x64, DisplaySize64x32, DisplaySize64x48,
+        DisplaySize72x40, DisplaySize96x16,
     },
 };
 


### PR DESCRIPTION
Hi! Thank you for helping out with SSD1306 development! Please:

- [ ] Check that you've added documentation to any new methods
- [ ] Rebase from `master` if you're not already up to date
- [ ] Add or modify an example if there are changes to the public API
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [ ] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [ ] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

I noticed that 64x32 was missing in prelude