### PR TITLE
- Update dependcies for `embedded-hal-bus` to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,14 @@
 [`ssd1306`](https://crates.io/crates/ssd1306) is a no-std driver written in Rust for the popular
 SSD1306 monochrome OLED display.
 
-<!-- next-header -->
+## [Unreleased] - ReleaseDate
+- Update dependcies for `embedded-hal-bus` to 0.3.0
+- Switch iterator in `write_str` in mode/terminal.rs  from last() to next_back (see https://rust-lang.github.io/rust-clippy/master/index.html#double_ended_iterator_last)
+- parenthese for expression in in mode/terminal.rs (see https://rust-lang.github.io/rust-clippy/master/index.html#precedence) in mode/terminal.rs
+- If feature `async`is enabled, the embedded_hal_async::i2c::I2  is used instead of embedded_hal::i2c::I2c  so I2c can shared
+- Update examples
+
+
 
 ## [Unreleased] - ReleaseDate
 - Update dependencies for  `embassy-executor` to 0.7.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ embassy-stm32 = { version = "0.2.0", features = [
 ] }
 embassy-time = { version = "0.4.0" }
 embassy-futures = "0.1.1"
-embedded-hal-bus = { version = "0.2.0", features = ["async"] }
+embedded-hal-bus = { version = "0.3.0", features = ["async"] }
 
 [features]
 default = ["graphics"]

--- a/examples/graphics_i2c.rs
+++ b/examples/graphics_i2c.rs
@@ -21,6 +21,8 @@ use cortex_m::asm::nop;
 use cortex_m_rt::entry;
 use defmt_rtt as _;
 use embassy_stm32::time::Hertz;
+#[cfg(feature = "async")]
+use embassy_stm32::{bind_interrupts, i2c, peripherals};
 use embedded_graphics::{
     pixelcolor::BinaryColor,
     prelude::*,
@@ -32,6 +34,25 @@ use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
 #[entry]
 fn main() -> ! {
     let p = embassy_stm32::init(Default::default());
+    #[cfg(feature = "async")]
+    bind_interrupts!(struct Irqs {
+        I2C1_EV => i2c::EventInterruptHandler<peripherals::I2C1>;
+        I2C1_ER => i2c::ErrorInterruptHandler<peripherals::I2C1>;
+    });
+
+    #[cfg(feature = "async")]
+    let i2c = embassy_stm32::i2c::I2c::new(
+        p.I2C1,
+        p.PB6,
+        p.PB7,
+        Irqs,
+        p.DMA1_CH6,
+        p.DMA1_CH7,
+        Hertz::khz(400),
+        Default::default(),
+    );
+
+    #[cfg(not(feature = "async"))]
     let i2c = embassy_stm32::i2c::I2c::new_blocking(
         p.I2C1,
         p.PB6,

--- a/examples/graphics_i2c_128x32.rs
+++ b/examples/graphics_i2c_128x32.rs
@@ -21,6 +21,8 @@ use cortex_m::asm::nop;
 use cortex_m_rt::entry;
 use defmt_rtt as _;
 use embassy_stm32::time::Hertz;
+#[cfg(feature = "async")]
+use embassy_stm32::{bind_interrupts, i2c, peripherals};
 use embedded_graphics::{
     pixelcolor::BinaryColor,
     prelude::*,
@@ -32,6 +34,25 @@ use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
 #[entry]
 fn main() -> ! {
     let p = embassy_stm32::init(Default::default());
+    #[cfg(feature = "async")]
+    bind_interrupts!(struct Irqs {
+        I2C1_EV => i2c::EventInterruptHandler<peripherals::I2C1>;
+        I2C1_ER => i2c::ErrorInterruptHandler<peripherals::I2C1>;
+    });
+
+    #[cfg(feature = "async")]
+    let i2c = embassy_stm32::i2c::I2c::new(
+        p.I2C1,
+        p.PB6,
+        p.PB7,
+        Irqs,
+        p.DMA1_CH6,
+        p.DMA1_CH7,
+        Hertz::khz(400),
+        Default::default(),
+    );
+
+    #[cfg(not(feature = "async"))]
     let i2c = embassy_stm32::i2c::I2c::new_blocking(
         p.I2C1,
         p.PB6,

--- a/examples/graphics_i2c_72x40.rs
+++ b/examples/graphics_i2c_72x40.rs
@@ -21,6 +21,8 @@ use cortex_m::asm::nop;
 use cortex_m_rt::entry;
 use defmt_rtt as _;
 use embassy_stm32::time::Hertz;
+#[cfg(feature = "async")]
+use embassy_stm32::{bind_interrupts, i2c, peripherals};
 use embedded_graphics::{
     pixelcolor::BinaryColor,
     prelude::*,
@@ -32,6 +34,25 @@ use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
 #[entry]
 fn main() -> ! {
     let p = embassy_stm32::init(Default::default());
+    #[cfg(feature = "async")]
+    bind_interrupts!(struct Irqs {
+        I2C1_EV => i2c::EventInterruptHandler<peripherals::I2C1>;
+        I2C1_ER => i2c::ErrorInterruptHandler<peripherals::I2C1>;
+    });
+
+    #[cfg(feature = "async")]
+    let i2c = embassy_stm32::i2c::I2c::new(
+        p.I2C1,
+        p.PB6,
+        p.PB7,
+        Irqs,
+        p.DMA1_CH6,
+        p.DMA1_CH7,
+        Hertz::khz(400),
+        Default::default(),
+    );
+
+    #[cfg(not(feature = "async"))]
     let i2c = embassy_stm32::i2c::I2c::new_blocking(
         p.I2C1,
         p.PB6,

--- a/examples/image_i2c.rs
+++ b/examples/image_i2c.rs
@@ -26,6 +26,9 @@
 use cortex_m::asm::nop;
 use cortex_m_rt::entry;
 use defmt_rtt as _;
+#[cfg(feature = "async")]
+use embassy_stm32::{bind_interrupts, i2c, peripherals};
+
 use embassy_stm32::time::Hertz;
 use embedded_graphics::{
     image::{Image, ImageRaw},
@@ -38,6 +41,25 @@ use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
 #[entry]
 fn main() -> ! {
     let p = embassy_stm32::init(Default::default());
+    #[cfg(feature = "async")]
+    bind_interrupts!(struct Irqs {
+        I2C1_EV => i2c::EventInterruptHandler<peripherals::I2C1>;
+        I2C1_ER => i2c::ErrorInterruptHandler<peripherals::I2C1>;
+    });
+
+    #[cfg(feature = "async")]
+    let i2c = embassy_stm32::i2c::I2c::new(
+        p.I2C1,
+        p.PB6,
+        p.PB7,
+        Irqs,
+        p.DMA1_CH6,
+        p.DMA1_CH7,
+        Hertz::khz(400),
+        Default::default(),
+    );
+
+    #[cfg(not(feature = "async"))]
     let i2c = embassy_stm32::i2c::I2c::new_blocking(
         p.I2C1,
         p.PB6,

--- a/examples/noise_i2c.rs
+++ b/examples/noise_i2c.rs
@@ -21,6 +21,9 @@
 
 use cortex_m_rt::entry;
 use defmt_rtt as _;
+#[cfg(feature = "async")]
+use embassy_stm32::{bind_interrupts, i2c, peripherals};
+
 use embassy_stm32::time::Hertz;
 use panic_probe as _;
 use rand::prelude::*;
@@ -29,6 +32,25 @@ use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
 #[entry]
 fn main() -> ! {
     let p = embassy_stm32::init(Default::default());
+    #[cfg(feature = "async")]
+    bind_interrupts!(struct Irqs {
+        I2C1_EV => i2c::EventInterruptHandler<peripherals::I2C1>;
+        I2C1_ER => i2c::ErrorInterruptHandler<peripherals::I2C1>;
+    });
+
+    #[cfg(feature = "async")]
+    let i2c = embassy_stm32::i2c::I2c::new(
+        p.I2C1,
+        p.PB6,
+        p.PB7,
+        Irqs,
+        p.DMA1_CH6,
+        p.DMA1_CH7,
+        Hertz::khz(400),
+        Default::default(),
+    );
+
+    #[cfg(not(feature = "async"))]
     let i2c = embassy_stm32::i2c::I2c::new_blocking(
         p.I2C1,
         p.PB6,

--- a/examples/rotation_i2c.rs
+++ b/examples/rotation_i2c.rs
@@ -27,6 +27,8 @@ use cortex_m::asm::nop;
 use cortex_m_rt::entry;
 use defmt_rtt as _;
 use embassy_stm32::time::Hertz;
+#[cfg(feature = "async")]
+use embassy_stm32::{bind_interrupts, i2c, peripherals};
 use embedded_graphics::{
     image::{Image, ImageRaw},
     pixelcolor::BinaryColor,
@@ -38,6 +40,25 @@ use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
 #[entry]
 fn main() -> ! {
     let p = embassy_stm32::init(Default::default());
+    #[cfg(feature = "async")]
+    bind_interrupts!(struct Irqs {
+        I2C1_EV => i2c::EventInterruptHandler<peripherals::I2C1>;
+        I2C1_ER => i2c::ErrorInterruptHandler<peripherals::I2C1>;
+    });
+
+    #[cfg(feature = "async")]
+    let i2c = embassy_stm32::i2c::I2c::new(
+        p.I2C1,
+        p.PB6,
+        p.PB7,
+        Irqs,
+        p.DMA1_CH6,
+        p.DMA1_CH7,
+        Hertz::khz(400),
+        Default::default(),
+    );
+
+    #[cfg(not(feature = "async"))]
     let i2c = embassy_stm32::i2c::I2c::new_blocking(
         p.I2C1,
         p.PB6,

--- a/examples/terminal_i2c.rs
+++ b/examples/terminal_i2c.rs
@@ -21,12 +21,33 @@ use core::fmt::Write;
 use cortex_m_rt::entry;
 use defmt_rtt as _;
 use embassy_stm32::time::Hertz;
+#[cfg(feature = "async")]
+use embassy_stm32::{bind_interrupts, i2c, peripherals};
 use panic_probe as _;
 use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
 
 #[entry]
 fn main() -> ! {
     let p = embassy_stm32::init(Default::default());
+    #[cfg(feature = "async")]
+    bind_interrupts!(struct Irqs {
+        I2C1_EV => i2c::EventInterruptHandler<peripherals::I2C1>;
+        I2C1_ER => i2c::ErrorInterruptHandler<peripherals::I2C1>;
+    });
+
+    #[cfg(feature = "async")]
+    let i2c = embassy_stm32::i2c::I2c::new(
+        p.I2C1,
+        p.PB6,
+        p.PB7,
+        Irqs,
+        p.DMA1_CH6,
+        p.DMA1_CH7,
+        Hertz::khz(400),
+        Default::default(),
+    );
+
+    #[cfg(not(feature = "async"))]
     let i2c = embassy_stm32::i2c::I2c::new_blocking(
         p.I2C1,
         p.PB6,

--- a/src/i2c_interface.rs
+++ b/src/i2c_interface.rs
@@ -8,6 +8,7 @@ pub struct I2CDisplayInterface(());
 
 impl I2CDisplayInterface {
     /// Create new builder with a default I2C address of 0x3C
+    #[cfg(not(feature = "async"))]
     #[allow(clippy::new_ret_no_self)]
     // pub fn with_i2c<I>(i2c: I) -> I2CInterface<I> // alternative, but breaking change
     pub fn new<I>(i2c: I) -> I2CInterface<I>
@@ -16,7 +17,17 @@ impl I2CDisplayInterface {
     {
         Self::new_custom_address(i2c, 0x3C)
     }
+    #[cfg(feature = "async")]
+    #[allow(clippy::new_ret_no_self)]
+    /// Create a new async I2C interface with the address 0x3D
+    pub fn new<I>(i2c: I) -> I2CInterface<I>
+    where
+        I: embedded_hal_async::i2c::I2c,
+    {
+        Self::new_custom_address(i2c, 0x3C)
+    }
 
+    #[cfg(not(feature = "async"))]
     /// Create a new I2C interface with the alternate address 0x3D as specified in the datasheet.
     pub fn new_alternate_address<I>(i2c: I) -> I2CInterface<I>
     where
@@ -25,10 +36,28 @@ impl I2CDisplayInterface {
         Self::new_custom_address(i2c, 0x3D)
     }
 
+    #[cfg(feature = "async")]
+    /// Create a new async I2C interface with the alternate address 0x3D as specified in the datasheet.
+    pub fn new_alternate_address<I>(i2c: I) -> I2CInterface<I>
+    where
+        I: embedded_hal_async::i2c::I2c,
+    {
+        Self::new_custom_address(i2c, 0x3D)
+    }
+
+    #[cfg(not(feature = "async"))]
     /// Create a new I2C interface with a custom address.
     pub fn new_custom_address<I>(i2c: I, address: u8) -> I2CInterface<I>
     where
         I: embedded_hal::i2c::I2c,
+    {
+        I2CInterface::new(i2c, address, 0x40)
+    }
+    #[cfg(feature = "async")]
+    /// Create a new  async I2C interface with a custom address.
+    pub fn new_custom_address<I>(i2c: I, address: u8) -> I2CInterface<I>
+    where
+        I: embedded_hal_async::i2c::I2c,
     {
         I2CInterface::new(i2c, address, 0x40)
     }

--- a/src/mode/terminal.rs
+++ b/src/mode/terminal.rs
@@ -592,7 +592,7 @@ where
         for (col, source) in bitmap.iter().enumerate() {
             // source.msb is the top pixel
             for (row, item) in rotated.iter_mut().enumerate() {
-                let bit = source & 1 << row != 0;
+                let bit = source & (1 << row) != 0;
                 if bit {
                     *item |= 1 << col;
                 }
@@ -624,7 +624,7 @@ where
     SIZE: TerminalDisplaySize,
 {
     fn write_str(&mut self, s: &str) -> Result<(), fmt::Error> {
-        s.chars().map(move |c| self.print_char(c)).last();
+        s.chars().map(move |c| self.print_char(c)).next_back();
         Ok(())
     }
 }


### PR DESCRIPTION

Hi! Thank you for helping out with SSD1306 development! Please:

- [ ] Check that you've added documentation to any new methods
- [ ] Rebase from `master` if you're not already up to date
- [ ] Add or modify an example if there are changes to the public API
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [ ] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [ ] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

- Switch iterator in `write_str` in mode/terminal.rs  from last() to next_back (see https://rust-lang.github.io/rust-clippy/master/index.html#double_ended_iterator_last)
- parenthese for expression in in mode/terminal.rs (see https://rust-lang.github.io/rust-clippy/master/index.html#precedence) in mode/terminal.rs
- If feature `async` is enabled, the embedded_hal_async::i2c::I2  is used instead of embedded_hal::i2c::I2c  so I2c can shared
- Update examples

