### PR TITLE
Enable resolver ver2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ SSD1306 monochrome OLED display.
 - Update examples
 
 ### Fixed
+- Switch to resolver ver2; it fixes compilation issues when `async` feature enabled.
 - Parentheses for expression in mode/terminal.rs (see [precedence](https://rust-lang.github.io/rust-clippy/master/index.html#precedence)) in mode/terminal.rs
 - Switch iterator in `write_str` in mode/terminal.rs  from last() to next_back (see [double_ended_iterator_last](https://rust-lang.github.io/rust-clippy/master/index.html#double_ended_iterator_last))
 - If feature `async` is enabled, the `embedded_hal_async::i2c::I2c`  is used instead of `embedded_hal::i2c::I2c`  so the I2C can be shared

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ SSD1306 monochrome OLED display.
 - Update examples
 
 ### Fixed
-- Switch to resolver ver2; it fixes compilation issues when `async` feature enabled.
+- Switch to resolver version 2. This fixes compilation issues when the `async` feature is enabled.
 - Parentheses for expression in mode/terminal.rs (see [precedence](https://rust-lang.github.io/rust-clippy/master/index.html#precedence)) in mode/terminal.rs
 - Switch iterator in `write_str` in mode/terminal.rs  from last() to next_back (see [double_ended_iterator_last](https://rust-lang.github.io/rust-clippy/master/index.html#double_ended_iterator_last))
 - If feature `async` is enabled, the `embedded_hal_async::i2c::I2c`  is used instead of `embedded_hal::i2c::I2c`  so the I2C can be shared

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.9.0"
 edition = "2021"
 exclude = ["build.rs", "build.sh", "memory.x", "doc", "*.jpg", "*.png", "*.bmp"]
 rust-version = "1.75.0"
+resolver = "2"
 
 [package.metadata.docs.rs]
 targets = ["thumbv7m-none-eabi", "thumbv7em-none-eabihf"]


### PR DESCRIPTION
As maybe-async-cfg crate docs suggested

Hi! Thank you for helping out with SSD1306 development! Please:

- [ ] Check that you've added documentation to any new methods
- [ ] Rebase from `master` if you're not already up to date
- [ ] Add or modify an example if there are changes to the public API
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [ ] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [ ] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

`maybe_async_cfg` crate suggested to add resolver v2 directive. For me it fixes compilation issues.

> RECOMMENDATION: Enable resolver ver2 in your crate, which is introduced in Rust 1.51. If not, two crates in dependency with conflict version (one async and another blocking) can fail compilation.
