### PR TITLE
Fix typo in i2c documentation

### DIFF
--- a/src/i2c_interface.rs
+++ b/src/i2c_interface.rs
@@ -19,7 +19,7 @@ impl I2CDisplayInterface {
     }
     #[cfg(feature = "async")]
     #[allow(clippy::new_ret_no_self)]
-    /// Create a new async I2C interface with the address 0x3D
+    /// Create a new async I2C interface with the address 0x3C
     pub fn new<I>(i2c: I) -> I2CInterface<I>
     where
         I: embedded_hal_async::i2c::I2c,


### PR DESCRIPTION
Hi! Thank you for helping out with SSD1306 development! Please:

- [ ] Check that you've added documentation to any new methods
- [ ] Rebase from `master` if you're not already up to date
- [ ] Add or modify an example if there are changes to the public API
- [ ] Add a `CHANGELOG.md` entry in the **Unreleased** section under the appropriate heading (**Added**, **Fixed**, **Changed**, etc)
- [ ] Run `rustfmt` on the project with `cargo fmt --all` - CI will not pass without this step
- [ ] Check that your branch is up to date with master and that CI is passing once the PR is opened

## PR description

Unharmful typo fix in i2c interface documentation, 0x3C is the default address.
